### PR TITLE
Added a line of code to prevent text skipping

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -2080,7 +2080,7 @@ What would you like to do?";
                                         switch (direction)
                                         {
                                             case "jump":
-                                                text = "You jump into the fog from where you are. Hope you know the laws physics reaaally well...";
+                                                text = "You jump into the fog from where you are. Hope you know the laws of physics reaaally well...";
                                                 Typewriter(text, delay);
                                                 Thread.Sleep(1000);
                                                 soundID = 26;
@@ -2438,8 +2438,14 @@ The snail finds you, sucks your blood, and eats your corpse.";
 
                     if (key == ConsoleKey.Spacebar)
                     {
+                        Console.Write(c);
                         delay = 0;
                         Volume(0);
+                    }
+                    else 
+                    {
+                        Console.Write(c);
+                        Thread.Sleep(delay);
                     }
                 }
                 else


### PR DESCRIPTION
## Description
[Added a line of code that places the last character when the spacebar is pressed, and prevented accidental keystrokes from erroneously skipping text. Additionally, corrected a typo in dialogue.]

## Related Issue
[https://github.com/ThomasMakinson/project-25-s2-snailgame/issues/14]

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
[Console Debug and Playtesting]

## Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
