### PR TITLE
Fixed Inventory and Items not working after reentering room 4

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1320,6 +1320,31 @@ You scream as you fall. An even larger snail eats you";
                                 direction = Console.ReadLine().ToLower().Trim();
                                 switch (direction)
                                 {
+                                    case "pick up unknown pills":
+                                    case "pick up pills":
+                                    case "grab unknown pills":
+                                    case "grab pills":
+                                        AddToInventory(unknownPills);
+                                        Console.WriteLine($"You added {unknownPills.Name} to your Inventory.");
+                                        Thread.Sleep(1500);
+                                        unknownPills.RoomID = -1;
+                                        break;
+                                    case "inventory":
+                                    case "check inventory":
+                                        items.DisplayInventory(inventory);
+                                        break;
+
+                                    case var command when command.StartsWith("use "):
+                                        foreach (items item in inventory)
+                                            if (item != null && item.Name.ToLower() == command.Substring(4).Trim())
+                                            { item.Use(); break; }
+                                        break;
+
+                                    case var command2 when command2.StartsWith("inspect "):
+                                        foreach (items item in inventory)
+                                            if (item != null && item.Name.ToLower() == command2.Substring(8).Trim())
+                                            { item.Inspect(); break; }
+                                        break;
                                     case "right":
                                         animationID = 43;
                                         Animations(ref animationID);
@@ -1404,6 +1429,9 @@ As you fall, an even larger snail eats you.";
                                                 text = "You stand there, contemplating your life choices. The snail finds you and eats you.";
                                                 Typewriter(text, delay);
                                                 Thread.Sleep(1200);
+                                                animationID = 2; //death animation
+                                                Animations(ref animationID);
+                                                runGame = 0; //makes you die
                                                 break;
                                         }
                                         break;


### PR DESCRIPTION
## Description
Fixed issue in Room 4, where the inventory and item functions weren't working, also added missing death animation when dying in room 4.

## Related Issue
[Fixed Inventory and Items not working after reentering room 4](https://github.com/ThomasMakinson/project-25-s2-snailgame/commit/0b1a5ebd495cbb6910eafa608652aa2a6bd55df6)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?
Visual Studio Run and Debug

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
